### PR TITLE
Add Cython and C++ sources to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include cython/spline_wrap.pyx
+include cpp/include/spline.hpp
+include cpp/src/spline.cpp

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     long_description_content_type='text/markdown',
     ext_modules = cythonize(ext_modules, language_level = "3"),
     py_modules = ["multispline.spline"],
+    include_package_data=True,
     cmdclass = {'build_ext': build_ext},
     zip_safe = False
 )


### PR DESCRIPTION
Hi,

I am working with [FastEMRIWaveforms](https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms) on a `linux_aarch64` architecture (linux docker on a Mac M4 laptop) and when I try to install FEW, the install fails due to an issue with its dependency on `multispline`.

Since there are no `manylinux_aarch64` wheels for `multispline` on PyPI, my install falls back to a local build using the sdist `multispline-0.8.2.tar.gz`. However, this fails quickly with the error message: `ValueError: 'cython/spline_wrap.pyx' doesn't match any files`.

It turns out that the files

- `cython/spline_wrap.pyx`
- `cpp/include/spline.hpp`
- `cpp/src/spline.cpp`

are not included in the source distribution which prevents building multispline from sdist.

The pull request fixes that by simply adding those three files to a `MANIFEST.in` file.