### PR TITLE
ci: Enable QEMU to build manylinux aarch64 wheels

### DIFF
--- a/.github/workflows/.build-package.yml
+++ b/.github/workflows/.build-package.yml
@@ -32,18 +32,55 @@ jobs:
 
   build_wheels:
     needs: build_and_run_tests
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} ${{ matrix.arch_linux }} ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [macos-13, macos-14]
+        include:
+          - os: ubuntu-latest
+            arch_linux: x86_64
+            cibw_skip: pp* *manylinux*
+            target: musllinux
+          - os: ubuntu-latest
+            arch_linux: i686
+            cibw_skip: pp* *manylinux*
+            target: musllinux
+          - os: ubuntu-latest
+            arch_linux: x86_64
+            cibw_skip: pp* *musllinux*
+            target: manylinux
+          - os: ubuntu-latest
+            arch_linux: i686
+            cibw_skip: pp* *musllinux*
+            target: manylinux
+          - os: ubuntu-latest
+            arch_linux: aarch64
+            cibw_skip: pp* *musllinux*
+            target: manylinux
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build wheels (Linux ${{ matrix.arch_linux }}-${{ matrix.target }} )
+        if: ${{ matrix.arch_linux }}
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_ARCHS_LINUX: ${{ matrix.arch_linux }}
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
+      
+      - name: Build wheels (macOS)
+        if: runner.os == 'macOS'
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_ARCHS_MACOS: x86_64 universal2 arm64
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Following yesterday discussion in #2 , here is the PR to enable manylinux_aarch64 wheels.
It was not sufficient to add `aarch64` to the `CIBW_ARCHS_LINUX` env var: it was also necessary to enable QEMU to enable emulation of non x86_64 architecture on the Linux runner [as documented here](https://cibuildwheel.pypa.io/en/stable/faq/#emulation).

I also took that opportunity to bump the cibuildwheel action to v2.22.0 and to enable `universal2` wheels on macOS (which contain both the x86_64 and arm64 version of the package to work on both Intel and Apple Silicon CPU).

Finally, due to the increased number of wheels to build on Linux, the workflow execution time reached about 3h. I speed it up by extending the `build_wheels` matrix to build in parallel the following targets:
- musllinux_x86_64
- musllinux_i686
- manylinux_x86_64
- manylinux_i686
- manylinux_aarch64

The musllinux_aarch64 was excluded as not a single wheel was built even after 25 minutes.

This updated workflow works with the new packaging (that I will include in the next PR) and should also work with the current `setup.py`-based packaging.
