### PR TITLE
Fix new build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MULTISPLINE_MARCH native CACHE STRING
                                  "Value of the -march compiler option if supported by compiler")
 
 # Define the splinecy target
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/cython")
 
 add_custom_command(
     OUTPUT "cython/spline_wrap.cpp"


### PR DESCRIPTION
Since migrating the build process to `scikit-build-core`, the `cythonize` part of the process is handled by CMake but the cythonize operation requires the directory of the output file to already exist on some platforms.
This caused issues when trying to automate building a conda package for `multispline`.

This PR fixes that issue.