### PR TITLE
fix: memory leak in cython wrappers for cpp classes

### DIFF
--- a/cython/spline_wrap.pyx
+++ b/cython/spline_wrap.pyx
@@ -99,6 +99,9 @@ cdef class CyCubicSpline:
             fvec[i] = f[i]
         self.scpp = new CubicSpline(x0, dx, fvec, method)
 
+    def __dealloc__(self):
+        del self.scpp
+
     def coefficient(self, int i, int j):
         return self.scpp.getSplineCoefficient(i, j)
 
@@ -121,6 +124,9 @@ cdef class CyBicubicSpline:
             for j in range(ny + 1):
                 mz.set_value(i, j, f[i, j])
         self.scpp = new BicubicSpline(x0, dx, nx, y0, dy, ny, mz, method)
+
+    def __dealloc__(self):
+        del self.scpp
 
     def coefficient(self, int i, int j, int nx, int ny):
         return self.scpp.getSplineCoefficient(i, j, nx, ny)
@@ -159,6 +165,9 @@ cdef class CyTricubicSpline:
         self.nz = nz
         cdef ThreeTensor ftens = ThreeTensor(fnx, fny, fnz, &f[0,0,0])
         self.scpp = new TricubicSpline(x0, dx, nx, y0, dy, ny, z0, dz, nz, ftens, method)
+
+    def __dealloc__(self):
+        del self.scpp
 
     def coefficient(self, int i, int j, int k, int nx, int ny, int nz):
         return self.scpp.getSplineCoefficient(i, j, k, nx, ny, nz)


### PR DESCRIPTION
By performing memory profiling of FEW tests, I discovered that each time we create a `TricubicSpline` object, it allocates memory that is never released.

The issue lies in those Cython lines:

```cython
cdef class CyTricubicSpline:
    cdef TricubicSpline *scpp
    ...

    def __init__(self, double x0, double dx, int nx, double y0, double dy, int ny, double z0, double dz, int nz, np.ndarray[ndim=3, dtype=np.float64_t, mode='c'] f, int method):
        cdef int fnx, fny, fnz
        ...
        self.scpp = new TricubicSpline(x0, dx, nx, y0, dy, ny, z0, dz, nz, ftens, method)
```

The `new` operation does not have a corresponding `delete`. I thus added to classes `CyTricubicSpline`, `CyBicubicSpline` and `CyCubicSpline` a `__dealloc__` method to free that memory properly:

```python
    def __dealloc__(self):
        del self.scpp
```

Now memory usage does not increase over time. I think this fix should quickly be added to a `0.8.4` release so that FEW tests can benefit from this.