### PR TITLE
fix wheel builds for macos

### DIFF
--- a/.github/workflows/.build-package.yml
+++ b/.github/workflows/.build-package.yml
@@ -36,8 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [macos-13, macos-14]
+        os: [macos-14]
         include:
           - os: ubuntu-latest
             arch_linux: x86_64


### PR DESCRIPTION
I noticed that the wheel upload failed for version 0.8.4.
It seems that the issue comes from the fact that the `macos-13` and `macos-14` runners build exactly the same wheels, so the job artifacts cannot be combined in the same directory.

I simply removed the macos 13 runner for the wheel build process and the issue should be fixed.
Unfortunately it will be required to tag a new 0.8.5 for the build and upload process to restart...